### PR TITLE
Rebuild the CLA system and enable `--word` Arg

### DIFF
--- a/folderJunker.cpp
+++ b/folderJunker.cpp
@@ -62,10 +62,11 @@ int main(int argc, char const *argv[]) {
     for (int i = 0; i < argc; i++) {
       if (COMP(argv[i], "-w") || COMP(argv[i], "--word")) {
         hasW = true;
-        word = argv[i + 1];
+        argv[i + 1] == NULL ? word = "folder_Junker" : word = argv[i + 1];
       } else if (COMP(argv[i], "-n") || COMP(argv[i], "--number")) {
         hasN = true;
         number = std::stoi(argv[i + 1]);
+        number < 1 ? number = 1 : number = std::stoi(argv[i + 1]);
       }
     }
 

--- a/folderJunker.cpp
+++ b/folderJunker.cpp
@@ -36,6 +36,20 @@ int main(int argc, char const *argv[]) {
     FJ::FolderJunker *fj = new FJ::FolderJunker();
     fj->initializeTitle();
 
+    if (COMP(argv[1], "-v") || COMP(argv[1], "--version")) {
+      std::cout << "Current App version: " << FJ::currentVersion << std::endl;
+      std::cout << "Developed by: Mushfiqur Rahman Abir\n"
+                << "Year: 2021\n";
+
+      exit(0);
+    }
+
+    if (COMP(argv[1], "-h") || COMP(argv[1], "--help")) {
+      FJ::Help help;
+      help.listAvailableCommands();
+      exit(0);
+    }
+
     std::string word;
     // Check if the user has passed any arguments or not
     for (int i = 0; i < argc; i++) {
@@ -81,16 +95,6 @@ int main(int argc, char const *argv[]) {
       }
     }
 
-    if (COMP(argv[1], "-v") || COMP(argv[1], "--version")) {
-      std::cout << "Current App version: " << FJ::currentVersion << std::endl;
-      std::cout << "Developed by: Mushfiqur Rahman Abir\n"
-                << "Year: 2021\n";
-    }
-
-    else if (COMP(argv[1], "-h") || COMP(argv[1], "--help")) {
-      FJ::Help help;
-      help.listAvailableCommands();
-    }
     // Delete the fj object
     delete fj;
   }

--- a/folderJunker.cpp
+++ b/folderJunker.cpp
@@ -23,6 +23,9 @@ Abir Year: 2021 Build System: CMake
 
 // Driver Function
 int main(int argc, char const *argv[]) {
+  bool hasW = false;
+  bool hasN = false;
+
   if (argc <= 1) /* If no args passed */
     std::cout
         << "No arguments passed. Specify the numbers of folder you want to "
@@ -33,17 +36,22 @@ int main(int argc, char const *argv[]) {
     FJ::FolderJunker *fj = new FJ::FolderJunker();
     fj->initializeTitle();
 
-    if (COMP(argv[1], "-v") || COMP(argv[1], "--version")) {
-      std::cout << "Current App version: " << FJ::currentVersion << std::endl;
-      std::cout << "Developed by: Mushfiqur Rahman Abir\n"
-                << "Year: 2021\n";
+    std::string word;
+    // Check if the user has passed any arguments or not
+    for (int i = 0; i < argc; i++) {
+      if (COMP(argv[i], "-w") || COMP(argv[i], "--word")) {
+        hasW = true;
+        word = argv[i + 1];
+      } else if (COMP(argv[i], "-n") || COMP(argv[i], "--number")) {
+        hasN = true;
+      }
     }
 
-    else if (COMP(argv[1], "-h") || COMP(argv[1], "--help")) {
-      FJ::Help help;
-      help.listAvailableCommands();
-    } else /* For handling  positive int args */
-    {
+    if (hasN) {
+      if (hasW) {
+        fj->createFolders(word.c_str(), 5);
+      }
+    } else {
       try {
         int val = std::stoi(argv[1]); // Convert the char* to int
 
@@ -71,6 +79,17 @@ int main(int argc, char const *argv[]) {
         std::cerr << "Errors occured ! Please try again. Error no "
                   << UNKNOWN_ERR << std::endl;
       }
+    }
+
+    if (COMP(argv[1], "-v") || COMP(argv[1], "--version")) {
+      std::cout << "Current App version: " << FJ::currentVersion << std::endl;
+      std::cout << "Developed by: Mushfiqur Rahman Abir\n"
+                << "Year: 2021\n";
+    }
+
+    else if (COMP(argv[1], "-h") || COMP(argv[1], "--help")) {
+      FJ::Help help;
+      help.listAvailableCommands();
     }
     // Delete the fj object
     delete fj;

--- a/folderJunker.cpp
+++ b/folderJunker.cpp
@@ -33,11 +33,15 @@ int main(int argc, char const *argv[]) {
            "folderJunker --help for more info.";
   else /* If args are passed */
   {
+    // Variables to check CLA
     bool hasW = false;
     bool hasN = false;
 
+    // Variables to store the CLA or other values
     std::string word;
     int number;
+
+    // Create an object of the FolderJunker class
     FJ::FolderJunker *fj = new FJ::FolderJunker();
     fj->initializeTitle();
 
@@ -73,10 +77,8 @@ int main(int argc, char const *argv[]) {
     // If --number is passed then only check for the --word/other arguments
     // which depends on the --number argument
     if (hasN) {
-      if (hasW)
-        fj->createFolders(word.c_str(), number);
-      else
-        fj->createFolders(number);
+      hasW ? fj->createFolders(word.c_str(), number)
+           : fj->createFolders(number);
     } else {
       try {
         int val = std::stoi(argv[1]); // Convert the char* to int

--- a/folderJunker.cpp
+++ b/folderJunker.cpp
@@ -92,7 +92,7 @@ int main(int argc, char const *argv[]) {
     if (hasN) {
       hasW ? fj->createFolders(word.c_str(), number)
            : fj->createFolders(number);
-    } else {
+    } else { /* Keeping this code for backward version compatibility */
       try {
         int val = std::stoi(argv[1]); // Convert the char* to int
 

--- a/folderJunker.cpp
+++ b/folderJunker.cpp
@@ -7,6 +7,10 @@ Abir Year: 2021 Build System: CMake
 
 // TODO: if 1 is passed then show folder instead of folders
 // TODO: Increase the version number to 2.0.0 when merged
+// TODO: Add a new command to delete the folders created by this tool
+// TODO: Add a disclaimer or warning when numbers are passed to the -w arg as
+// when numbers are passed, the random words generator will not be able to
+// create enough random words
 
 // Includes
 #include <cstring>

--- a/folderJunker.cpp
+++ b/folderJunker.cpp
@@ -6,6 +6,7 @@ Abir Year: 2021 Build System: CMake
 */
 
 // TODO: if 1 is passed then show folder instead of folders
+// TODO: Increase the version number to 2.0.0 when merged
 
 // Includes
 #include <cstring>
@@ -69,7 +70,15 @@ int main(int argc, char const *argv[]) {
         argv[i + 1] == NULL ? word = "folder_Junker" : word = argv[i + 1];
       } else if (COMP(argv[i], "-n") || COMP(argv[i], "--number")) {
         hasN = true;
-        number = std::stoi(argv[i + 1]);
+        try {
+          number = std::stoi(argv[i + 1]);
+        } catch (std::invalid_argument) {
+          std::cerr
+              << "Invalid argument passed. Please provide positive numbers "
+                 "as arguments. "
+                 "Error no "
+              << INVALID_ARG << std::endl;
+        }
         number < 1 ? number = 1 : number = std::stoi(argv[i + 1]);
       }
     }

--- a/folderJunker.cpp
+++ b/folderJunker.cpp
@@ -5,6 +5,8 @@ of this tool will be of course for test purposes. Developed By: Mushfiqur Rahman
 Abir Year: 2021 Build System: CMake
 */
 
+// TODO: if 1 is passed then show folder instead of folders
+
 // Includes
 #include <cstring>
 #include <iostream>
@@ -23,8 +25,6 @@ Abir Year: 2021 Build System: CMake
 
 // Driver Function
 int main(int argc, char const *argv[]) {
-  bool hasW = false;
-  bool hasN = false;
 
   if (argc <= 1) /* If no args passed */
     std::cout
@@ -33,9 +33,17 @@ int main(int argc, char const *argv[]) {
            "folderJunker --help for more info.";
   else /* If args are passed */
   {
+    bool hasW = false;
+    bool hasN = false;
+
+    std::string word;
+    int number;
     FJ::FolderJunker *fj = new FJ::FolderJunker();
     fj->initializeTitle();
 
+    // Check for the version and help commands first and then check for the
+    // other. If help or version is passed, then show the help or version and
+    // exit the program.
     if (COMP(argv[1], "-v") || COMP(argv[1], "--version")) {
       std::cout << "Current App version: " << FJ::currentVersion << std::endl;
       std::cout << "Developed by: Mushfiqur Rahman Abir\n"
@@ -50,21 +58,24 @@ int main(int argc, char const *argv[]) {
       exit(0);
     }
 
-    std::string word;
-    // Check if the user has passed any arguments or not
+    // Check if the user has passed any other arguments or not
     for (int i = 0; i < argc; i++) {
       if (COMP(argv[i], "-w") || COMP(argv[i], "--word")) {
         hasW = true;
         word = argv[i + 1];
       } else if (COMP(argv[i], "-n") || COMP(argv[i], "--number")) {
         hasN = true;
+        number = std::stoi(argv[i + 1]);
       }
     }
 
+    // If --number is passed then only check for the --word/other arguments
+    // which depends on the --number argument
     if (hasN) {
-      if (hasW) {
-        fj->createFolders(word.c_str(), 5);
-      }
+      if (hasW)
+        fj->createFolders(word.c_str(), number);
+      else
+        fj->createFolders(number);
     } else {
       try {
         int val = std::stoi(argv[1]); // Convert the char* to int

--- a/libfj/include/availableCommands.hpp
+++ b/libfj/include/availableCommands.hpp
@@ -3,8 +3,7 @@
 
 #include <iostream>
 
-const std::string availCmd[] = {
-    "-h, --help",
-    "-v, --version"};
+const std::string availCmd[] = {"-h, --help", "-v, --version", "-w, --word",
+                                "-n, --number"};
 
 #endif // AVAILABLECOMMANDS_HPP

--- a/libfj/src/fjhome.cpp
+++ b/libfj/src/fjhome.cpp
@@ -12,8 +12,6 @@ void FolderJunker::initializeTitle() {
 
 // The main createFolders function that creates folders with custom names |
 // Overloaded function
-// TODO: Add a feature to create folders with custom names. This function is
-// currently not working.
 void FolderJunker::createFolders(const char *folderName, int numbers) {
   std::cout << "Creating " << numbers << " folders named " << folderName
             << " in this current directory..." << std::endl;


### PR DESCRIPTION
- The tool now accepts mutiple args passed
- Accepts args in any order 
- The `-w`, `--word` arg now works like a charm
- New `-n`, `--number` arg now enabled & is recommended to use all the time

Fixes #7 